### PR TITLE
Added var "postfix_dkim_key_bits" for changing opendkim key size

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ postfix_use_procmail: no
 # Install opendkim and setup postfix to use DKIM
 postfix_dkim: no
 postfix_dkim_domain: "{{inventory_hostname}}"
+postfix_dkim_key_bits: 2048
 
 # Relay all mail going to local users (e.g. root or cron) to another mail address
 postfix_local_user_relay_address: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,6 +33,7 @@ postfix_spf: no
 # Install opendkim and setup postfix to use DKIM
 postfix_dkim: no
 postfix_dkim_domains:
+postfix_dkim_key_bits: 2048
 
 # Install opendmarc and setup postfix to use DMARC
 postfix_dmarc: no

--- a/tasks/opendkim.yml
+++ b/tasks/opendkim.yml
@@ -21,7 +21,7 @@
   notify: opendkim restart
 
 - name: Generate DKIM keys
-  command: opendkim-genkey -s mail -d "{{ item }}"
+  command: opendkim-genkey -s mail -b "{{ postfix_dkim_key_bits }}" -d "{{ item }}"
   args:
     chdir: "/etc/opendkim/{{ item }}"
     creates: "/etc/opendkim/{{ item }}/mail.private"


### PR DESCRIPTION
Just added a new var "postfix_dkim_key_bits" for specifying opendkim key length. This is needed because some registrars like Namecheap don't allow setting a TXT register with a 2048 bits key.