### PR TITLE
Using refile: and *@domain in signing_table

### DIFF
--- a/templates/opendkim.conf.j2
+++ b/templates/opendkim.conf.j2
@@ -13,7 +13,7 @@ UMask                   002
 Socket                  inet:12301@localhost
 
 KeyTable                /etc/opendkim/key_table
-SigningTable            /etc/opendkim/signing_table
+SigningTable            refile:/etc/opendkim/signing_table
 ExternalIgnoreList      /etc/opendkim/trusted_hosts
 InternalHosts           /etc/opendkim/trusted_hosts
 AutoRestart             Yes

--- a/templates/signing_table.j2
+++ b/templates/signing_table.j2
@@ -3,5 +3,5 @@
 # Do NOT modify this file by hand!
 
 {% for domain in postfix_dkim_domains %}
-{{ domain }} mail._domainkey.{{ domain }}
+*@{{ domain }} mail._domainkey.{{ domain }}
 {% endfor %}


### PR DESCRIPTION
The role was not working for me on Debian Jessie. 

It seems like there was a problem in the signing_table file, so it should have this format:

`*@example.com mail._domainkey.example.com`

This also needs adding "refile:" before the SigningTable value in opendkim.conf

(more info here http://opendkim.org/opendkim-README)